### PR TITLE
Telegrafana Docker example

### DIFF
--- a/examples/telegrafana/README.md
+++ b/examples/telegrafana/README.md
@@ -1,0 +1,31 @@
+### Objective
+
+This example shows how we can run telegraf and grafana to show CPU, MEM and DISK usage directly on a host (or send from multiple hosts using telegraf to an observability host)
+
+### Things to note
+
+The docker compose file contains all components necessary to run this example in a 'All-in-One' Scenario, where we want to monitor the usage metrics via Telegraf Agent and want to inspect it on that host directly.
+
+Data is fed from Telegraf Agent directly into Gigapi and can be consumed either via Grafana or via Gigapi UI.
+
+A token can be specified, but is not necessary. You may see a warning about a token being unspecified, this is okay and acceptable.
+
+### How to run
+
+On a new host place this folders contents,
+then run:
+```bash
+docker compose pull
+```
+To get the latest images.
+And then run:
+```bash
+docker compose up -d
+```
+To start the services.
+
+Once up, you can either navigate to the localhost port 3000 for Grafana (default user:password is admin:admin) or to port 7971 to use Gigapi UI.
+
+Telegraf will send usage metrics based on the telegraf.conf. Using telegraf's documentation you can add additional metrics to your hearts content.
+
+You may also use other agents, utilizing the influxdb line format exporter.

--- a/examples/telegrafana/docker-compose.yml
+++ b/examples/telegrafana/docker-compose.yml
@@ -1,0 +1,46 @@
+volumes:
+  grafana_data: {}
+services:
+  gigapi:
+    image: ghcr.io/gigapi/gigapi:latest
+    container_name: gigapi
+    hostname: gigapi
+    restart: unless-stopped
+    volumes:
+      - ./data:/data
+    ports:
+      - "7971:7971"
+      - "8082:8082"
+    environment:
+      - GIGAPI_ROOT=/data
+
+  telegraf:
+    image: telegraf:latest
+    container_name: telegraf
+    network_mode: host
+    hostname: telegraf
+    restart: unless-stopped
+    volumes:
+      - ./telegraf.conf:/etc/telegraf/telegraf.conf:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /etc:/host/etc:ro
+    depends_on:
+      - gigapi
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - 3000:3000
+    environment:
+      - INFLUX_HOST=iox:8082
+      - INFLUX_TOKEN=${INFLUXDB_TOKEN}
+      - INFLUX_ORG=gigapi
+      - INFLUX_BUCKET=sensors
+      - GF_INSTALL_PLUGINS=influxdata-flightsql-datasource
+    volumes:
+      - ./flightsql.yml:/etc/grafana/provisioning/datasources/flightsql.yml
+      - grafana_data:/var/lib/grafana/
+    restart: always
+    depends_on:
+      - gigapi

--- a/examples/telegrafana/flightsql.yml
+++ b/examples/telegrafana/flightsql.yml
@@ -1,0 +1,21 @@
+apiVersion: 1
+
+datasources:
+  - name: FlightSQL
+    type: influxdata-flightsql-datasource
+    typeName: FlightSQL
+    access: proxy
+    url: ''
+    user: ''
+    database: ''
+    basicAuth: false
+    isDefault: true
+    jsonData:
+      host: gigapi:8082
+      metadata:
+      - bucket-name: telegraf
+      - database: telegraf
+      secure: false
+      token: ${INFLUX_TOKEN}
+    readOnly: false
+    editable: true

--- a/examples/telegrafana/telegraf.conf
+++ b/examples/telegrafana/telegraf.conf
@@ -1,0 +1,36 @@
+# Global Telegraf Configuration
+[agent]
+  interval = "15s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "10s"
+  flush_jitter = "0s"
+  precision = ""
+  hostname = ""
+  omit_hostname = false
+
+# Input Plugins - Collecting System Metrics
+[[inputs.cpu]]
+  percpu = true
+  totalcpu = true
+  collect_cpu_time = false
+  report_active = false
+
+[[inputs.mem]]
+
+[[inputs.disk]]
+  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
+
+[[inputs.system]]
+
+
+[[outputs.influxdb]]
+  urls = ["http://gigapi:7971"]
+  database = "telegraf"
+  skip_database_creation = true
+  exclude_retention_policy_tag = true
+  exclude_database_tag = true
+  content_encoding = "identity"
+  namepass = ["cpu", "mem", "disk", "system"]


### PR DESCRIPTION
Using Telegraf Agent and Grafana as UI, show system metrics of the local host machine.